### PR TITLE
courses.yml: Set difficulty to 0

### DIFF
--- a/course.yml
+++ b/course.yml
@@ -3,7 +3,7 @@ title: Introduction to R
 instructors:
  - jonathan+author@datacamp.com
 time_needed: 4 hours
-difficulty_level: 1
+difficulty_level: 0
 description: "In this introduction to R, you will master the basics of this beautiful
   open source language, including factors, lists and data frames. With the knowledge
   gained in this course, you will be ready to undertake your first very own data


### PR DESCRIPTION
The 3 courses shown below "Starting your Data Science journey" are chosen by difficulty. 
If the difficulty isn't set to zero, then it isn't shown there.

See: https://www.datacamp.com/courses